### PR TITLE
fix: querystring order in canonical string

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -78,6 +78,7 @@ export class AWSSignerV4 implements Signer {
 
     const urlObj = new URL(request.url);
     const { host, pathname, searchParams } = urlObj;
+    searchParams.sort();
     const canonicalQuerystring = searchParams.toString();
 
     const headers = new Headers(request.headers);


### PR DESCRIPTION
after a lot of research, gallons of coffee, poring through the official sdk and just overall banging my head on my keyboard trying to figure this one out ... turns out we only needed to sort the query string parameters before calculating the signature.

---
When adding a `continuation-token` to the query string in a `listObject` operation for s3 for example, if the query string parameters are not sorted, AWS refuses the signature with a `SignatureDoesNotMatch`.