### PR TITLE
Use HMAC SHA-256 implementation from /std

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,14 +1,12 @@
-import { createHash } from "https://deno.land/std@0.95.0/hash/mod.ts";
-export function sha256Hex(data: string | Uint8Array): string {
-  const hasher = createHash("sha256");
-  hasher.update(data);
-  return hasher.toString("hex");
+import { HmacSha256, Sha256 } from "https://deno.land/std@0.95.0/hash/sha256.ts";
+import type { Message } from "https://deno.land/std@0.95.0/hash/sha256.ts";
+
+export function sha256(data: Message): Sha256 {
+  const hasher = new Sha256();
+  return hasher.update(data);
 }
 
-import { HmacSha256 } from "https://deno.land/std@0.95.0/hash/sha256.ts";
-import type { Message } from "https://deno.land/std@0.95.0/hash/sha256.ts";
 export function hmacSha256(key: Message, data: Message): HmacSha256 {
   const hasher = new HmacSha256(key);
-  hasher.update(data);
-  return hasher;
+  return hasher.update(data);
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,8 +1,14 @@
-export { hmac } from "https://deno.land/x/hmac@v2.0.1/mod.ts";
-
 import { createHash } from "https://deno.land/std@0.95.0/hash/mod.ts";
 export function sha256Hex(data: string | Uint8Array): string {
   const hasher = createHash("sha256");
   hasher.update(data);
   return hasher.toString("hex");
+}
+
+import { HmacSha256 } from "https://deno.land/std@0.95.0/hash/sha256.ts";
+import type { Message } from "https://deno.land/std@0.95.0/hash/sha256.ts";
+export function hmacSha256(key: Message, data: Message): HmacSha256 {
+  const hasher = new HmacSha256(key);
+  hasher.update(data);
+  return hasher;
 }

--- a/deps.ts
+++ b/deps.ts
@@ -1,4 +1,7 @@
-import { HmacSha256, Sha256 } from "https://deno.land/std@0.95.0/hash/sha256.ts";
+import {
+  HmacSha256,
+  Sha256,
+} from "https://deno.land/std@0.95.0/hash/sha256.ts";
 import type { Message } from "https://deno.land/std@0.95.0/hash/sha256.ts";
 
 export function sha256(data: Message): Sha256 {

--- a/mod.ts
+++ b/mod.ts
@@ -1,4 +1,4 @@
-import { sha256Hex } from "./deps.ts";
+import { sha256 } from "./deps.ts";
 import { toAmz, toDateStamp } from "./src/date.ts";
 export { toAmz, toDateStamp };
 import { getSignatureKey, signAwsV4 } from "./src/signing.ts";
@@ -96,13 +96,13 @@ export class AWSSignerV4 implements Signer {
     const body = request.body
       ? new Uint8Array(await request.arrayBuffer())
       : null;
-    const payloadHash = sha256Hex(body ?? new Uint8Array());
+    const payloadHash = sha256(body ?? new Uint8Array()).hex();
 
     const { awsAccessKeyId, awsSecretKey } = this.credentials;
 
     const canonicalRequest =
       `${request.method}\n${pathname}\n${canonicalQuerystring}\n${canonicalHeaders}\n${signedHeaders}\n${payloadHash}`;
-    const canonicalRequestDigest = sha256Hex(canonicalRequest);
+    const canonicalRequestDigest = sha256(canonicalRequest).hex();
 
     const algorithm = "AWS4-HMAC-SHA256";
     const credentialScope =

--- a/src/signing.ts
+++ b/src/signing.ts
@@ -1,4 +1,4 @@
-import { hmac } from "../deps.ts";
+import { hmacSha256 } from "../deps.ts";
 const encoder = new TextEncoder();
 const AWS4: Uint8Array = encoder.encode("AWS4");
 
@@ -11,7 +11,7 @@ export const signAwsV4 = (
   key: string | Uint8Array,
   msg: string,
 ): string | Uint8Array => {
-  return hmac("sha256", key, msg, undefined, "hex");
+  return hmacSha256(key, msg).hex();
 };
 
 /**
@@ -36,16 +36,14 @@ export const getSignatureKey = (
   paddedKey.set(AWS4, 0);
   paddedKey.set(key, 4);
 
-  let mac: Uint8Array = hmac(
-    "sha256",
+  let mac = hmacSha256(
     paddedKey,
-    dateStamp as string,
-    "utf8",
-  ) as Uint8Array;
+    dateStamp,
+  ).arrayBuffer();
 
-  mac = hmac("sha256", mac, region, "utf8") as Uint8Array;
-  mac = hmac("sha256", mac, service, "utf8") as Uint8Array;
-  mac = hmac("sha256", mac, "aws4_request", "utf8") as Uint8Array;
+  mac = hmacSha256(mac, region).arrayBuffer();
+  mac = hmacSha256(mac, service).arrayBuffer();
+  mac = hmacSha256(mac, "aws4_request").arrayBuffer();
 
-  return mac;
+  return new Uint8Array(mac);
 };


### PR DESCRIPTION
Fixes #3 

I didn't want to change any exported signatures, so `getSignatureKey` is constructing a `Uint8Array` on return (for `signAwsV4`) even though a basic `ArrayBuffer` would work fine. `/std/hash/sha256.ts` has a `Message` union type including `number[]` which I believe is what allows the `ArrayBuffer` inputs.

The tests pass for me, but I also noticed that they don't seem to test for any particular generated signature, just the overall behavior/framing. So maybe this can be practically tested in another module.

And of course, here's a before/after of the package import graph:

![Screenshot 2021-04-26 09 35 46](https://user-images.githubusercontent.com/40628/116046547-7a67b980-a673-11eb-800a-4bbffb8fe1a0.png)
