### PR TITLE
fix: Correctly canonicalize query param spaces

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,10 @@
 import { toAmz, toDateStamp } from "./src/date.ts";
+import { toCanonicalQueryString } from "./src/encodeUri.ts";
 export { toAmz, toDateStamp };
 import { getSignatureKey, signAwsV4 } from "./src/signing.ts";
 import { sha256Hex } from "./src/util.ts";
+
+export { encodeUriS3 } from "./src/encodeUri.ts";
 
 /**
  * Generic AWS Signer interface
@@ -75,9 +78,7 @@ export class AWSSignerV4 implements Signer {
 
     const urlObj = new URL(request.url);
     const { host, pathname, searchParams } = urlObj;
-    searchParams.sort();
-	// per https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html#create-canonical-request
-    const canonicalQuerystring = searchParams.toString().replaceAll("+", "%20");
+    const canonicalQuerystring = toCanonicalQueryString(searchParams);
 
     const headers = new Headers(request.headers);
 

--- a/mod.ts
+++ b/mod.ts
@@ -76,7 +76,8 @@ export class AWSSignerV4 implements Signer {
     const urlObj = new URL(request.url);
     const { host, pathname, searchParams } = urlObj;
     searchParams.sort();
-    const canonicalQuerystring = searchParams.toString();
+	// per https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html#create-canonical-request
+    const canonicalQuerystring = searchParams.toString().replaceAll("+", "%20");
 
     const headers = new Headers(request.headers);
 

--- a/src/encodeUri.ts
+++ b/src/encodeUri.ts
@@ -1,0 +1,41 @@
+// per https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html#create-canonical-request
+
+const encoder = new TextEncoder();
+
+export function encodeUriS3(input: string, isQueryParam = false): string {
+  let result = "";
+  for (const ch of input) {
+    if (
+      (ch >= "A" && ch <= "Z") ||
+      (ch >= "a" && ch <= "z") ||
+      (ch >= "0" && ch <= "9") ||
+      ch == "_" ||
+      ch == "-" ||
+      ch == "~" ||
+      ch == "."
+    ) {
+      result += ch;
+	} else if (!isQueryParam && ch == "/") {
+      result += "/";
+    } else {
+      result += stringToHex(ch);
+    }
+  }
+  return result;
+}
+
+function stringToHex(input: string) {
+  return [...encoder.encode(input)]
+    .map((s) => "%" + s.toString(16).padStart(2, '0'))
+    .join("")
+    .toUpperCase();
+}
+
+export function toCanonicalQueryString(search: URLSearchParams | string) {
+  const queryParams = new URLSearchParams(search);
+  queryParams.sort();
+
+  return [...queryParams.entries()].map(([k, v]) =>
+    [encodeUriS3(k, true), encodeUriS3(v, true)].join("=")
+  ).join("&");
+}


### PR DESCRIPTION
This, along with https://github.com/lucacasonato/deno_s3/pull/55, will fix https://github.com/lucacasonato/deno_s3/issues/54.

`URLSearchParams#toString()` canonicalizes spaces in keys or values to `+`:
```js
new URL('https://example.com/?a%20b=c%20d').searchParams.toString() // 'a+b=c+d'
```

Whereas AWS requires them to be percent-encoded. Per https://docs.aws.amazon.com/general/latest/gr/create-signed-request.html#create-canonical-request:

> `CanonicalQueryString` – The URL-encoded query string parameters, separated by ampersands (&). Percent-encode reserved characters, including the space character.